### PR TITLE
fix: allow same version in npm publish workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,7 +113,7 @@ jobs:
         
       - name: Update package.json version
         run: |
-          npm version ${{ steps.get_version.outputs.VERSION }} --no-git-tag-version
+          npm version ${{ steps.get_version.outputs.VERSION }} --no-git-tag-version --allow-same-version
           
       - name: Publish to npm
         run: npm publish --access public

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,10 @@ jobs:
           
       - name: Get release version
         id: get_version
-        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+        run: |
+          TAG=${GITHUB_REF#refs/tags/}
+          echo "TAG=$TAG" >> $GITHUB_OUTPUT
+          echo "VERSION=${TAG#v}" >> $GITHUB_OUTPUT
         
       - name: Download release assets
         run: |
@@ -58,7 +61,7 @@ jobs:
           sleep 10
           
           # Download binaries from the release
-          gh release download v${{ steps.get_version.outputs.VERSION }} \
+          gh release download ${{ steps.get_version.outputs.TAG }} \
             --pattern "cadence-codegen_Darwin_x86_64.tar.gz" \
             --pattern "cadence-codegen_Darwin_arm64.tar.gz" \
             --pattern "cadence-codegen_Linux_x86_64.tar.gz" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,10 +48,7 @@ jobs:
           
       - name: Get release version
         id: get_version
-        run: |
-          TAG=${GITHUB_REF#refs/tags/}
-          echo "TAG=$TAG" >> $GITHUB_OUTPUT
-          echo "VERSION=${TAG#v}" >> $GITHUB_OUTPUT
+        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
         
       - name: Download release assets
         run: |
@@ -61,7 +58,7 @@ jobs:
           sleep 10
           
           # Download binaries from the release
-          gh release download ${{ steps.get_version.outputs.TAG }} \
+          gh release download v${{ steps.get_version.outputs.VERSION }} \
             --pattern "cadence-codegen_Darwin_x86_64.tar.gz" \
             --pattern "cadence-codegen_Darwin_arm64.tar.gz" \
             --pattern "cadence-codegen_Linux_x86_64.tar.gz" \


### PR DESCRIPTION
## Summary
- Add `--allow-same-version` flag to `npm version` in release workflow to prevent failure when `package.json` already matches the release tag version

## Context
The `npm-publish` job fails with "Version not changed" when the tag version matches the existing `package.json` version (e.g. both are `1.0.0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)